### PR TITLE
Add support for Java programming language

### DIFF
--- a/python/languages/java.py
+++ b/python/languages/java.py
@@ -1,0 +1,34 @@
+from typing import List
+
+from task_maker.args import Arch
+from task_maker.languages import CompiledLanguage, CommandType, LanguageManager
+
+
+class LanguageJava(CompiledLanguage):
+    @property
+    def name(self):
+        return "Java"
+
+    @property
+    def source_extensions(self):
+        return [".java"]
+
+    def get_compilation_command(self, source_filenames: List[str],
+                                exe_name: str, unit_name: str,
+                                for_evaluation: bool,
+                                target_arch: Arch) -> (CommandType, List[str]):
+
+        main_class = "grader" if "grader.java" in source_filenames else unit_name
+        commands = [
+            f"javac {' '.join(source_filenames)}",
+            f"echo Main-Class: {main_class} > MANIFEST.MF",
+            f"jar cvmf MANIFEST.MF {exe_name} *.class",
+        ]
+        return CommandType.SYSTEM, ["sh", "-c", "&&".join(commands)]
+
+    def get_execution_command(self, exe_name: str, args: List[str], main=None) -> (CommandType, List[str]):
+        return CommandType.SYSTEM, ["java", "-jar", exe_name, *args]
+
+
+def register():
+    LanguageManager.register_language(LanguageJava())


### PR DESCRIPTION
This is a serious PR, since I need Task Maker to support Java for one course of Romeo that uses this language. I tested it with tasks with and without graders and it seems to work fine. 

What I do is similar to what CMS does, compile all the sources, then create a jar file with all the .class files (they could be more than the source files, for example if you use inside a single file nested classes). I also create a manifest file to indicate the main class, that is either the name of the task or grader. 